### PR TITLE
Prevent local expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - We no longer construct a faulty local command when the SSH username isn't set
-
+- Ensure we shellescape the remote command to prevent issues when it contains special characters, like references to ENV variables.
 
 ## [0.2.0] - 2016-02-15
 

--- a/lib/capistrano/remote/runner.rb
+++ b/lib/capistrano/remote/runner.rb
@@ -44,7 +44,7 @@ module Capistrano
           'ssh',
           (user ? "-l #{user}" : nil),
           hostname,
-          "-t \"#{remote_command}\""
+          "-t #{Shellwords.escape(remote_command)}"
         ]
         local_command = parts.compact.join(' ')
         exec local_command


### PR DESCRIPTION
Fixes issues where the remote command contains references to ENV variables or
quotes or other special characters.