### PR TITLE
Update remote.rake

### DIFF
--- a/lib/capistrano/tasks/remote.rake
+++ b/lib/capistrano/tasks/remote.rake
@@ -5,7 +5,7 @@ namespace :remote do
     rails_env = fetch(:rails_env)
     on roles(:db) do |host|
       Capistrano::Remote::Runner.new(host).rails(
-        "console #{rails_env}"
+        "console -e #{rails_env}"
       )
     end
   end


### PR DESCRIPTION
fix rails 5 warning 

```
DEPRECATION WARNING: Passing the environment's name as a regular argument is deprecated and will be removed in the next Rails version. Please, use the -e option instead. (called from <main> at bin/rails:4)
```