### PR TITLE
Relax version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
--
+- Requirements for Bundler versions have been relaxed. We should work just fine on 10.0 and forward as we have done since the beginning of the project.
+
+- Requirements for Rake versions have been relaxed. We should work just fine on 1.17 and forward as we have done since the beginning of the project.
 
 ## [0.3.0] - 2019-09-25
 

--- a/capistrano-remote.gemspec
+++ b/capistrano-remote.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', '~> 3.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'rake', '>= 10.0'
 end


### PR DESCRIPTION
We should be able to function perfectly fine on Rake versions 10.0 and Bundler
1.17 and forward. At least, we have worked just fine since the beginning of the
project, and I am not aware of anything breaking that could have changed that.

Just because a new version has been released, doesn't mean we don't still work
on the older version.