### PR TITLE
fix passing of environment to dbconsole

### DIFF
--- a/lib/capistrano/tasks/remote.rake
+++ b/lib/capistrano/tasks/remote.rake
@@ -14,7 +14,7 @@ namespace :remote do
     rails_env = fetch(:rails_env)
     on roles(:db) do |host|
       Capistrano::Remote::Runner.new(host).rails(
-        "dbconsole #{rails_env} -p"
+        "dbconsole -e #{rails_env} -p"
       )
     end
   end


### PR DESCRIPTION
rails/rails@e20589c9 removed the option to pass the environment as argument. it must be passed as `-e <environment>` option. this is backwards-compatible.

closes #13